### PR TITLE
fix stream_parser: allow for message formats without timestamp

### DIFF
--- a/src/stream_parser/file_reader.rs
+++ b/src/stream_parser/file_reader.rs
@@ -358,8 +358,11 @@ impl<'c> LogParser<'c> {
                         ),
                     ));
                 }
-                let current_timestamp =
-                    flattened_format.timestamp_field.parse_timestamp(msg.data());
+                let timestamp_field = flattened_format.timestamp_field.as_ref().ok_or_else(|| UlogParseError::new(
+                    ParseErrorType::Other,
+                    &format!("Message does not have a timestamp field {}", flattened_format.message_name),
+                ))?;
+                let current_timestamp = timestamp_field.parse_timestamp(msg.data());
                 if *last_timestamp < current_timestamp {
                     *last_timestamp = current_timestamp;
                     if let Some(cb) = &mut self.data_message_callback {

--- a/src/stream_parser/model.rs
+++ b/src/stream_parser/model.rs
@@ -168,7 +168,7 @@ pub struct FlattenedFormat {
     pub message_name: String,
     pub fields: Vec<FlattenedField>,
     name_to_field: HashMap<String, FlattenedField>,
-    pub timestamp_field: TimestampField,
+    pub timestamp_field: Option<TimestampField>,
     size: u16,
 }
 
@@ -187,7 +187,7 @@ impl FlattenedFormat {
             .iter()
             .map(|f| (f.flattened_field_name.to_string(), (*f).clone()))
             .collect();
-        match name_to_field
+        let timestamp_field = name_to_field
             .get("timestamp")
             .and_then(|field| match field.field_type {
                 FlattenedFieldType::UInt8 => Some(TimestampField {
@@ -207,19 +207,14 @@ impl FlattenedFormat {
                     offset: field.offset,
                 }),
                 _ => None,
-            }) {
-            Some(timestamp_field) => Ok(Self {
-                message_name,
-                fields,
-                name_to_field,
-                timestamp_field,
-                size,
-            }),
-            None => Err(UlogParseError::new(
-                ParseErrorType::Other,
-                &format!("Message does not have a timestamp field {}", message_name),
-            )),
-        }
+            });
+        Ok(Self {
+            message_name,
+            fields,
+            name_to_field,
+            timestamp_field,
+            size,
+        })
     }
 
     pub fn get_field_offset(


### PR DESCRIPTION
E.g. nested formats are not required to contain a timestamp field.
Instead, the check is moved to when the timestamp is trying to be accessed
(which indicates an invalid ULog file).

I added 2 additional changes: parsing the FlagBits message, and simplifying `read_file_with_simple_callback` a bit.

I tested everything - would be good to have some more automated tests though.