### PR TITLE
Allow empty fields section in ULog format definitions

### DIFF
--- a/src/stream_parser/file_reader.rs
+++ b/src/stream_parser/file_reader.rs
@@ -517,7 +517,7 @@ fn parse_format(message: &model::ULogMessage) -> Result<Format, UlogParseError> 
 
     let parts: Vec<&str> = format.split(":").collect();
 
-    if parts.len() != 2 || parts.iter().any(|e| e.is_empty()) {
+    if parts.len() != 2 || parts.first().unwrap().is_empty() {
         return Err(UlogParseError::new(
             ParseErrorType::Other,
             &format!("invalid format string: {}", format),


### PR DESCRIPTION
Some ULog files contain format definitions with an empty fields section (e.g. `__rcl_interfaces/ParameterType:`). The parser rejects these as invalid and propagates the error, causing the entire file to fail parsing — no data is returned for any topic.

This change skips unrecognized format definitions instead of failing, allowing the rest of the file to parse normally.

## Update

Based on feedback, this PR has been updated to take a more targeted approach.

Instead of skipping unrecognized format definitions at the call site, the parser now accepts format definitions with an empty fields section by relaxing validation.

Previously, entries like `__rcl_interfaces/ParameterType:` were rejected because both parts of a `type:name` pair had to be non-empty. This now only requires the first part to be non-empty, allowing these definitions to be parsed as having no fields.

This avoids suppressing all parse_format errors while still preventing a single format definition from causing the entire file to fail parsing.